### PR TITLE
Initialiser les tests d'intégration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Learn more about the server's production configuration for `fr.openfisca.org` on
 
 ## Integration tests
 
-This code uses [Watai](https://github.com/MattiSG/Watai/wiki) framework for integration tests.
+This code uses [Watai](https://github.com/MattiSG/Watai/wiki) framework for integration testing.
 
 ### Install integration tests environment
 
-To run the tests with Watai, we need Java JRE and a Selenium standalone server.
+To run the tests with Watai, we need the Java JRE and a Selenium standalone server.
 
 #### Install Java JRE
 
@@ -39,10 +39,11 @@ java -version
 # Expected answer example: java version "1.8.0_40"
 ```
 
-If you get an error, download Java last `JRE` version on [Oracle website](http://www.oracle.com/technetwork/java/javase/downloads/jre9-downloads-3848532.html). 
+If you get an error, download Java last `JRE` version on the [Oracle website](http://www.oracle.com/technetwork/java/javase/downloads/jre9-downloads-3848532.html). 
 
 #### Install Selenium
-Download the standalone selenium server on the [official website](https://www.seleniumhq.org/download/).  
+
+Download the standalone Selenium server on the [official website](https://www.seleniumhq.org/download/).  
 
 Your download result is a Java `.jar` file (e.g., `selenium-server-standalone-3.4.0.jar`)   
 
@@ -68,6 +69,7 @@ Then, end it with Ctrl-C.
 
 
 #### Select testing browser
+
 To run the integration tests locally, you need a testing browser.
 Default configuration in this project uses Chrome browser.
 
@@ -85,6 +87,7 @@ If you don't have Chrome, update the browser name in `tests/integration/config.j
     browser: 'firefox',
 ```
 And this doesn't need further driver installation.
+
 #### Link Chromedriver & Selenium
 
 Go in the Selenium directory and add a (symbolic) link to the chrome driver:

--- a/README.md
+++ b/README.md
@@ -29,60 +29,101 @@ This code uses [Watai](https://github.com/MattiSG/Watai/wiki) framework for inte
 
 ### Install integration tests environment
 
-#### Selenium
-Watai needs a Selenium standalone server and describes installation instructions in its [documentation](https://github.com/MattiSG/Watai/wiki/Installing#selenium-server).
+To run the tests with Watai, we need Java JRE and a Selenium standalone server.
 
-To test your installation, run: 
+#### Install Java JRE
 
-```sh
-sudo selenium
+Check if a JRE is already installed on your environment with:
+```
+java -version
+# Expected answer example: java version "1.8.0_40"
 ```
 
-Or, without administrator's rights: 
+If you get an error, download Java last `JRE` version on [Oracle website](http://www.oracle.com/technetwork/java/javase/downloads/index.html). 
 
+#### Install Selenium
+Download the standalone selenium server on the [official website](https://www.seleniumhq.org/download/).  
+
+Your download result is a Java `.jar` file (e.g., `selenium-server-standalone-3.4.0.jar`)   
+
+Move this file to the desired directory.
+In this example, we will save it to: `/opt/local/lib/selenium`  
+
+And register the jar full path in `$SELENIUM` environment variable:
+```sh
+export SELENIUM=/opt/local/lib/selenium/selenium-server-standalone-3.4.0.jar
+```
+
+To test your installation, run: 
 ```sh
 java -jar $SELENIUM
-```  
-
-where `$SELENIUM` contains a path to Selenium standalone server jar file (e.g. `/usr/local/lib/node_modules/selenium-server/lib/runner/selenium-server-standalone-3.4.0.jar`).
+# Expected answer example:
+# 15:26:11.981 INFO - Selenium build info: version: '3.4.0', revision: 'unknown'
+# 15:26:11.982 INFO - Launching a standalone Selenium Server
+# (...)
+# 15:26:12.323 INFO - Selenium Server is up and running
+```
 
 Then, end it with Ctrl-C.
 
 
-#### Chromedriver
-To run the tests in development mode, you will need to install `chromedriver` as `tests/integration/config.js` is pre-configured to use Chrome browser:
+#### Select testing browser
+To run the integration tests locally, you need a testing browser.
+Default configuration in this project uses Chrome browser.
+
+If you have Chrome, install `chromedriver` as follows:
 
 ```sh
 sudo npm install —global chromedriver
 ```
-This will add a chromedriver to your global environment (e.g., `/usr/local/lib/node_modules/chromedriver`).
+This will add a chromedriver to your global environment.  
+Its installation directory (e.g., `/usr/local/lib/node_modules/chromedriver`) will be used in the next step.
 
+If you don't have Chrome, update the browser name in `tests/integration/config.js`. E.g., for `firefox`:
+
+```
+    browser: 'firefox',
+```
+And this doesn't need further driver installation.
 #### Link Chromedriver & Selenium
 
-Add chromedriver reference to selenium server by creating a symbolic link to the driver in selenium directory:
+Go in the Selenium directory and add a (symbolic) link to the chrome driver:
 
 ```sh
 cd `dirname $SELENIUM`
 sudo ln -s /usr/local/lib/node_modules/chromedriver/lib/chromedriver/chromedriver chromedriver
-
 ```
 
 ### Run tests
 
-1. Run the web site in developement mode:
+Every step is runned in a new terminal window.
 
+1. Terminal window #1: in `fr.openfisca.org` directory, run the web site in developement mode
 ```sh
 npm run dev
+# Expected answer example:  
+# DONE  Compiled successfully in 2276ms                                3:25:21 PM
+# > Ready on http://localhost:3000
 ```
 
-2. In a new terminal, run the selenium server:
+2. Terminal window #2: run the selenium server
 ```sh
 java -jar $SELENIUM 
+# Expected answer example:
+# 15:26:11.981 INFO - Selenium build info: version: '3.4.0', revision: 'unknown'
+# 15:26:11.982 INFO - Launching a standalone Selenium Server
+# (...)
+# 15:26:12.323 INFO - Selenium Server is up and running
 ```
 
-3. In an other terminal, run the integration tests (this step opens a new Chrome window):
+3. Terminal window #3: in `fr.openfisca.org` directory, run the integration tests (this step opens Chrome browser)
 ```sh
-npm run test
+npm run test:integration
+# Expected answer example:
+# (...)
+# ⨁  fr.openfisca.org                       
+# ✔  L'en-tête doit présenter ce que fait OpenFisca.
+# ✔  La page d'accueil doit indiquer les informations de documentation.
 ```
 
 ## Tracking

--- a/README.md
+++ b/README.md
@@ -12,16 +12,39 @@ This is the source code of the [web site](http://fr.openfisca.org) for the commu
 
 ## Install
 
+> This project uses [Next.js](https://github.com/zeit/next.js) and [React](https://reactjs.org).  
+
+To install this project's dependencies, go to its directory and run:
 ```sh
-yarn install
+npm install
 ```
 
-## Run
+## Run 
 
-Learn more about the server's production configuration for `fr.openfisca.org` on the [openfisca-ops repository](https://www.github.com/openfisca/openfisca-ops).
+* To run the website locally in a development mode, call:
+```sh
+npm run dev
+# Expected result example: 
+# DONE  Compiled successfully in 2285ms                                 10:22:29 PM
+# > Ready on http://localhost:3000
+```
 
+* To run the website in a production mode, build it then start it with:
+```sh
+npm run build
+# Expected result example: 
+# > next build
 
-## Test
+npm start
+# Expected result example:
+# > next start
+# > Ready on http://localhost:3000
+```
+
+> Learn more about the server's production configuration for `fr.openfisca.org` on the [openfisca-ops repository](https://www.github.com/openfisca/openfisca-ops).
+
+:tada: In your browser, the website is available at this address: `http://localhost:3000`
+
 
 ## Integration tests
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ To run the tests with Watai, we need Java JRE and a Selenium standalone server.
 
 #### Install Java JRE
 
-Check if a JRE is already installed on your environment with:
+Check if a Java Runtime Environment (JRE) is already installed on your environment with:
 ```
 java -version
 # Expected answer example: java version "1.8.0_40"
 ```
 
-If you get an error, download Java last `JRE` version on [Oracle website](http://www.oracle.com/technetwork/java/javase/downloads/index.html). 
+If you get an error, download Java last `JRE` version on [Oracle website](http://www.oracle.com/technetwork/java/javase/downloads/jre9-downloads-3848532.html). 
 
 #### Install Selenium
 Download the standalone selenium server on the [official website](https://www.seleniumhq.org/download/).  
@@ -74,7 +74,7 @@ Default configuration in this project uses Chrome browser.
 If you have Chrome, install `chromedriver` as follows:
 
 ```sh
-sudo npm install —global chromedriver
+sudo npm install --global chromedriver
 ```
 This will add a chromedriver to your global environment.  
 Its installation directory (e.g., `/usr/local/lib/node_modules/chromedriver`) will be used in the next step.

--- a/README.md
+++ b/README.md
@@ -16,22 +16,76 @@ This is the source code of the [web site](http://fr.openfisca.org) for the commu
 yarn install
 ```
 
-## Run locally
-
-```sh
-yarn run build
-yarn run dev
-```
-
-## Run on a server
-
-```sh
-yarn run build
-yarn run start
-```
+## Run
 
 Learn more about the server's production configuration for `fr.openfisca.org` on the [openfisca-ops repository](https://www.github.com/openfisca/openfisca-ops).
+
+
+## Test
+
+## Integration tests
+
+This code uses [Watai](https://github.com/MattiSG/Watai/wiki) framework for integration tests.
+
+### Install integration tests environment
+
+#### Selenium
+Watai needs a Selenium standalone server and describes installation instructions in its [documentation](https://github.com/MattiSG/Watai/wiki/Installing#selenium-server).
+
+To test your installation, run: 
+
+```sh
+sudo selenium
+```
+
+Or, without administrator's rights: 
+
+```sh
+java -jar $SELENIUM
+```  
+
+where `$SELENIUM` contains a path to Selenium standalone server jar file (e.g. `/usr/local/lib/node_modules/selenium-server/lib/runner/selenium-server-standalone-3.4.0.jar`).
+
+Then, end it with Ctrl-C.
+
+
+#### Chromedriver
+To run the tests in development mode, you will need to install `chromedriver` as `tests/integration/config.js` is pre-configured to use Chrome browser:
+
+```sh
+sudo npm install —global chromedriver
+```
+This will add a chromedriver to your global environment (e.g., `/usr/local/lib/node_modules/chromedriver`).
+
+#### Link Chromedriver & Selenium
+
+Add chromedriver reference to selenium server by creating a symbolic link to the driver in selenium directory:
+
+```sh
+cd `dirname $SELENIUM`
+sudo ln -s /usr/local/lib/node_modules/chromedriver/lib/chromedriver/chromedriver chromedriver
+
+```
+
+### Run tests
+
+1. Run the web site in developement mode:
+
+```sh
+npm run dev
+```
+
+2. In a new terminal, run the selenium server:
+```sh
+java -jar $SELENIUM 
+```
+
+3. In an other terminal, run the integration tests (this step opens a new Chrome window):
+```sh
+npm run test
+```
 
 ## Tracking
 
 fr.openfisca.org uses [Matomo](https://matomo.org/) (formerly Piwik) to track visits. The tracking is configured in `piwik.config.json`. Change the information there if you are running a seperate Piwik or Matomo instance.
+

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,43 @@
+machine:
+  node:
+    version: 6
+  environment:
+    SAUCE_LOG: $CIRCLE_ARTIFACTS/sauce_log.txt
+    WATAI_TESTS: tests/integration
+    SAUCE_USERNAME: openfisca
+    # SAUCE_ACCESS_KEY is defined in the CircleCI web UI
+    PORT: 3000 # Nextjs App serving port
+
+dependencies:
+  post:
+    - npm install saucelabs # allow sending Watai results to SauceLabs
+    - wget https://saucelabs.com/downloads/sc-4.4.9-linux.tar.gz
+    - tar -xzf sc-4.4.9-linux.tar.gz
+    - npm run build
+
+test:
+  pre:
+    - npm start:
+        background: true
+        parallel: true
+    # start Sauce Connect
+    - cd sc-*-linux && ./bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY --tunnel-identifier "circle-$CIRCLE_BUILD_NUM-$CIRCLE_NODE_INDEX" --readyfile ~/sauce_is_ready > $SAUCE_LOG:
+        background: true
+        parallel: true
+    # wait for Sauce Connect
+    - while [ ! -e ~/sauce_is_ready ]; do sleep 1; done:
+        parallel: true
+    # wait for server (after Sauce Connect because it is faster to start)
+    - wget --retry-connrefused --waitretry=1 --output-document=/dev/null http://localhost:$PORT:
+        parallel: true
+    # prepare CI-specific config holder and add CI-specific config to Watai
+    - mkdir $HOME/.watai && cp $WATAI_TESTS/config-ci.js $HOME/.watai/config.js:
+        parallel: true
+
+  override:
+    - npm test:
+        parallel: true
+
+  post:
+    - killall --wait sc:  # wait until Sauce Connect closes the tunnel
+        parallel: true

--- a/circle.yml
+++ b/circle.yml
@@ -9,11 +9,15 @@ machine:
     PORT: 3000 # Nextjs App serving port
 
 dependencies:
+  override:
+    - npm install
+    - npm list
+    - npm run build
+
   post:
     - npm install saucelabs # allow sending Watai results to SauceLabs
     - wget https://saucelabs.com/downloads/sc-4.4.9-linux.tar.gz
     - tar -xzf sc-4.4.9-linux.tar.gz
-    - npm run build
 
 test:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,6 @@ machine:
 dependencies:
   override:
     - npm install
-    - npm list
     - npm run build
 
   post:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "next": "^5.0.0",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react-dom": "^16.2.0",
+    "webpack-sources": "^1.1.0"
   },
   "devDependencies": {
     "watai": "^0.7.0"

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   "dependencies": {
     "next": "^5.0.0",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0",
-    "webpack-sources": "^1.1.0"
+    "react-dom": "^16.2.0"
   },
   "devDependencies": {
-    "watai": "^0.7.0"
+    "watai": "^0.7.0",
+    "webpack-sources": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,14 +7,19 @@
   "author": "OpenFisca Core Team",
   "license": "AGPL 3",
   "private": false,
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start",
+    "test:integration": "watai tests/integration",
+    "test": "npm run test:integration"
+  },
   "dependencies": {
     "next": "^5.0.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
   },
-  "scripts": {
-    "dev": "next",
-    "build": "next build",
-    "start": "next start"
+  "devDependencies": {
+    "watai": "^0.7.0"
   }
 }

--- a/tests/integration/1_AppScenario.js
+++ b/tests/integration/1_AppScenario.js
@@ -1,0 +1,7 @@
+description: "The header should show OpenFisca pitch",
+
+steps: [
+    {
+        "AppComponent.baseline": baseline
+    }
+]

--- a/tests/integration/1_AppScenario.js
+++ b/tests/integration/1_AppScenario.js
@@ -1,7 +1,7 @@
-description: "The header should show OpenFisca pitch",
+description: "L'en-tête doit présenter ce que fait OpenFisca.",
 
 steps: [
     {
-        "AppComponent.baseline": baseline
+        "AppComponent.pitch": pitch
     }
 ]

--- a/tests/integration/2_FindDocumentationScenario.js
+++ b/tests/integration/2_FindDocumentationScenario.js
@@ -1,0 +1,7 @@
+description: "La page d'accueil doit indiquer les informations de documentation.",
+
+steps: [
+  {
+    "AppComponent.docLink": docLink
+  }
+]

--- a/tests/integration/2_InstallOpenFiscaScenario.js
+++ b/tests/integration/2_InstallOpenFiscaScenario.js
@@ -1,7 +1,0 @@
-description: "The main page should contain a link to OpenFisca installation instructions.",
-
-steps: [
-  {
-    "AppComponent.installationLink": installationLink
-  }
-]

--- a/tests/integration/2_InstallOpenFiscaScenario.js
+++ b/tests/integration/2_InstallOpenFiscaScenario.js
@@ -1,0 +1,7 @@
+description: "The main page should contain a link to OpenFisca installation instructions.",
+
+steps: [
+  {
+    "AppComponent.installationLink": installationLink
+  }
+]

--- a/tests/integration/AppComponent.js
+++ b/tests/integration/AppComponent.js
@@ -1,0 +1,2 @@
+baseline: "h1",
+installationLink: {a: "TODO"}

--- a/tests/integration/AppComponent.js
+++ b/tests/integration/AppComponent.js
@@ -1,2 +1,2 @@
-baseline: "h1",
-installationLink: {a: "TODO"}
+pitch: "h1",
+docLink: {a: "Documentation"}

--- a/tests/integration/AppComponent.js
+++ b/tests/integration/AppComponent.js
@@ -1,2 +1,2 @@
 pitch: "h1",
-docLink: {a: "Documentation"}
+docLink: "a[href='http://openfisca.org/doc/']"

--- a/tests/integration/AppFixture.js
+++ b/tests/integration/AppFixture.js
@@ -1,2 +1,2 @@
-baseline = /OpenFisca modélise le système socio-fiscal français en code informatique./
-installationLink = "TODO"
+pitch = /OpenFisca modélise le système socio-fiscal français en code informatique./
+docLink = "http://openfisca.org/doc/"

--- a/tests/integration/AppFixture.js
+++ b/tests/integration/AppFixture.js
@@ -1,0 +1,2 @@
+baseline = /OpenFisca modélise le système socio-fiscal français en code informatique./
+installationLink = "TODO"

--- a/tests/integration/AppFixture.js
+++ b/tests/integration/AppFixture.js
@@ -1,2 +1,2 @@
 pitch = /OpenFisca modélise le système socio-fiscal français en code informatique./
-docLink = "http://openfisca.org/doc/"
+docLink = "Documentation"

--- a/tests/integration/config-ci.js
+++ b/tests/integration/config-ci.js
@@ -1,0 +1,19 @@
+// this file is for use in CircleCI continuous integration environment
+
+var browserName = ['chrome', 'firefox', 'internet explorer', 'android'][process.env.CIRCLE_NODE_INDEX];
+
+module.exports = {
+  seleniumServerURL: {
+    hostname: 'ondemand.saucelabs.com',
+    port: 80
+  },
+  driverCapabilities: {
+    'tunnel-identifier': 'circle-' + process.env.CIRCLE_BUILD_NUM + '-' + process.env.CIRCLE_NODE_INDEX,
+    browserName: browserName
+  },
+  tags: [ 'circle-ci', '#' + process.env.CIRCLE_BUILD_NUM ],
+  views: [ 'Verbose', 'SauceLabs' ],
+  quit: 'always', // avoid wasting 90 seconds on SauceLabs
+  bail: true,
+  build: 'CircleCI#' + process.env.CIRCLE_BUILD_NUM
+}

--- a/tests/integration/config.js
+++ b/tests/integration/config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    name: 'fr.openfisca.org',
+    baseURL: 'http://localhost:3000',
+    browser: 'chrome',
+}

--- a/tests/integration/config.js
+++ b/tests/integration/config.js
@@ -1,3 +1,5 @@
+//this file is used by Watai to run integration tests locally
+
 module.exports = {
     name: 'fr.openfisca.org',
     baseURL: 'http://localhost:3000',


### PR DESCRIPTION
Fixes openfisca/openfisca-web-site#64

Ajoute la structure de tests d'intégration au dépôt.
Initialise les tests watai.
Décrit la procédure de tests dans le README.
Configure l'exécution des tests sur circle ci avec saucelabs.


