### PR TITLE
Fix run tests step in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run:
           name: Install saucelabs
           command: |
-            npm install saucelabs --no-save # allow sending Watai results to SauceLabs. Don't save in package.json, as this would change its checksum and mess up the cache.
+            npm install saucelabs@1.5.0 --no-save # allow sending Watai results to SauceLabs. Don't save in package.json, as this would change its checksum and mess up the cache.
             if [ -d sc ]; then exit; fi  # sc has already been downloaded
             mkdir sc
             wget https://saucelabs.com/downloads/sc-4.4.9-linux.tar.gz --directory-prefix sc


### PR DESCRIPTION
* Fix CI `Run tests` step
  * Setting `saucelabs` version in CI config fixes `TypeError: SauceLabsTransmitter is not a constructor` error in CI

> `Run tests` goes from [ ❌ ](https://circleci.com/gh/openfisca/fr.openfisca.org/179) to [ ✅ ](https://circleci.com/gh/openfisca/fr.openfisca.org/180)