### PR TITLE
Update website service name

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -14,4 +14,4 @@ npm run build
 
 # The current user must have been specifically allowed to run the next command
 # Use the visudo command to do so
-sudo systemctl restart fr.openfisca.org-beta.service
+sudo systemctl restart fr.openfisca.org.service


### PR DESCRIPTION
Fixes [this build](https://circleci.com/gh/openfisca/fr.openfisca.org/185) error.

> `fr.openfisca.org-beta.service` is now running as `fr.openfisca.org.service`