### PR TITLE
Fix buttons in Communauté

### DIFF
--- a/pages/community.jsx
+++ b/pages/community.jsx
@@ -10,11 +10,11 @@ const Communaute = () => (
     <div className="content">
         <section>
             <h2>Qui sommes-nous ?</h2>
-            <div className="flex__container">
+            <div className="flex__column">
                 <div className="flex__item50">
-            OpenFisca est une communauté Open Source soutenue par Beta Gouv & Etalab, deux équipes d’innovation au sein du gouvernement français.
-            En 2019, OpenFisca est utilisée par 7 pays dans le monde (France, Espagne, Italie, Nouvelle Zélande, Sénégal & Tunisie).
-            Plus de 70 personnes ont rejoint cette aventure. Ils contribuent, s’entraident et participent chaque jour à améliorer le code d’OpenFisca.
+                    OpenFisca est une communauté Open Source soutenue par Beta Gouv & Etalab, deux équipes d’innovation au sein du gouvernement français.
+                    En 2019, OpenFisca est utilisée par 7 pays dans le monde (France, Espagne, Italie, Nouvelle Zélande, Sénégal & Tunisie).
+                    Plus de 70 personnes ont rejoint cette aventure. Ils contribuent, s’entraident et participent chaque jour à améliorer le code d’OpenFisca.
                 </div>
                 <div className="flex__item50">
                     <img src={asset('/images/community.png')} alt=""/>
@@ -24,7 +24,7 @@ const Communaute = () => (
 
         <section>
             <h2>Échanger avec la communauté</h2>
-            <div className="flex__container">
+            <div className="flex__column">
                 <div className="flex__item50">
                     <p>Lorsque vous travaillez sur un projet utilisant OpenFisca, vous êtes le bienvenue sur notre Slack ! Vous pourrez y demander de l’aide, des conseils et rencontrer les autres membres de la communauté.
         Avant de vous inviter sur le Slack, nous vous demandons simplement de répondre à quelques questions sur votre projet.
@@ -46,14 +46,16 @@ const Communaute = () => (
             </div>
         </section>
 
-        <div className="flex__container">
+        <section>
             <h2>Restez informés</h2>
-            <div className="flex__item50">
-                <p>Vous pouvez vous abonner à notre newsletter mensuelle pour recevoir les actualités et les changements majeurs opérés sur OpenFisca.
-                </p>
+            <div className="flex__column">
+                <div className="flex__item50">
+                    <p>Vous pouvez vous abonner à notre newsletter mensuelle pour recevoir les actualités et les changements majeurs opérés sur OpenFisca.
+                    </p>
+                </div>
+                <a className="btn medium">Recevoir la Newsletter</a>
             </div>
-            <a className="btn medium">Recevoir la Newsletter</a>
-        </div>
+        </section>
 
         <style jsx>{`
 

--- a/pages/community.jsx
+++ b/pages/community.jsx
@@ -10,11 +10,13 @@ const Communaute = () => (
     <div className="content">
         <section>
             <h2>Qui sommes-nous ?</h2>
-            <div className="flex__column">
+            <div className="flex__container">
                 <div className="flex__item50">
-                    OpenFisca est une communauté Open Source soutenue par Beta Gouv & Etalab, deux équipes d’innovation au sein du gouvernement français.
-                    En 2019, OpenFisca est utilisée par 7 pays dans le monde (France, Espagne, Italie, Nouvelle Zélande, Sénégal & Tunisie).
-                    Plus de 70 personnes ont rejoint cette aventure. Ils contribuent, s’entraident et participent chaque jour à améliorer le code d’OpenFisca.
+                    <p>
+                        OpenFisca est une communauté Open Source soutenue par Beta Gouv & Etalab, deux équipes d’innovation au sein du gouvernement français.
+                        En 2019, OpenFisca est utilisée par 7 pays dans le monde (France, Espagne, Italie, Nouvelle Zélande, Sénégal & Tunisie).
+                        Plus de 70 personnes ont rejoint cette aventure. Ils contribuent, s’entraident et participent chaque jour à améliorer le code d’OpenFisca.
+                    </p>
                 </div>
                 <div className="flex__item50">
                     <img src={asset('/images/community.png')} alt=""/>
@@ -26,8 +28,9 @@ const Communaute = () => (
             <h2>Échanger avec la communauté</h2>
             <div className="flex__column">
                 <div className="flex__item50">
-                    <p>Lorsque vous travaillez sur un projet utilisant OpenFisca, vous êtes le bienvenue sur notre Slack ! Vous pourrez y demander de l’aide, des conseils et rencontrer les autres membres de la communauté.
-        Avant de vous inviter sur le Slack, nous vous demandons simplement de répondre à quelques questions sur votre projet.
+                    <p>
+                        Lorsque vous travaillez sur un projet utilisant OpenFisca, vous êtes le bienvenue sur notre Slack ! Vous pourrez y demander de l’aide, des conseils et rencontrer les autres membres de la communauté.
+                        Avant de vous inviter sur le Slack, nous vous demandons simplement de répondre à quelques questions sur votre projet.
                     </p>
                 </div>
                 <a className="btn medium" href="https://forms.gle/XFxiFvfaAa6w7LGy7">Rejoindre le Slack</a>


### PR DESCRIPTION
* Fixes buttons sizes and location in page `Communauté`

> Tested on Google Chrome Version 73.0.3683.103.

Old page:

<img width="347" alt="Screen Shot 2019-04-24 at 14 03 30" src="https://user-images.githubusercontent.com/6567910/56658029-d4ef6900-6699-11e9-89e2-58695120500e.png">


New page:

<img width="360" alt="Screen Shot 2019-04-24 at 14 01 05" src="https://user-images.githubusercontent.com/6567910/56657909-8215b180-6699-11e9-9a00-1b3060502fee.png">