### PR TITLE
Centrer le logo d'accueil

### DIFF
--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -19,7 +19,6 @@ const Footer = () => (
                 <li><a href="https://forms.gle/XFxiFvfaAa6w7LGy7" passHref><img src="/static/icons/Slack.svg" alt="Slack"></img></a></li>
                 <li><a href="https://twitter.com/openfisca" passHref><img src="/static/icons/Twitter.svg" alt="Twitter"></img></a></li>
             </ul>
-
         </footer>
 
         <style jsx>{`
@@ -48,7 +47,7 @@ const Footer = () => (
 				float: right;
 			}
 
-			h3{
+			h3 {
 				align-text: center;
 				color: #ffffff;}
 

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -39,6 +39,12 @@ const Footer = () => (
 				text-align: center;
 				align-items: center;
 			}
+
+			.baseline img {
+				max-height: 1.5em;
+        		vertical-align: bottom;
+			}
+
 			.CTA {
 				max-width: 8em;
 			}
@@ -72,7 +78,8 @@ const Footer = () => (
 
 			@media (max-width: 720px) {
 				ul {
-					padding: 0;
+					display: flex;
+					padding: 0.2rem;
 					flex-direction: column;
 					align-items: center;
 				}

--- a/components/GlobalStyle.jsx
+++ b/components/GlobalStyle.jsx
@@ -11,7 +11,7 @@ const GlobalStyle = () => (
       box-sizing: border-box;
     }
 
-    body{
+    body {
       width: 100%;
       margin: 0;
       font-family: 'asapregular';
@@ -94,7 +94,6 @@ const GlobalStyle = () => (
         margin-right: 1em;
         display: flex;
         padding: 0.5em;
-        margin: 0.75em 0.5em 0 0;
       }
 
       .menu:after, .menu:hover, .menu:active {
@@ -116,6 +115,7 @@ const GlobalStyle = () => (
 				text-align: center;
 				white-space: nowrap;
         text-decoration: none;
+        margin: 0.75em 0.5em 0 0;
 			}
 
       h1 {
@@ -194,7 +194,6 @@ const GlobalStyle = () => (
         background-color:#ffffff;
         border: #ffffff 1px solid;
         padding: 0.5em;
-        margin: 0.75em 0.5em 0 0;
       }
 
       .btn {
@@ -223,9 +222,7 @@ const GlobalStyle = () => (
       .outline {
         color: #ffffff;
         border: #ffffff 1px solid;
-        display: flex;
         padding: 0.5em;
-        margin: 0.75em 0.5em 0 0;
       }
 
       .medium {

--- a/components/GlobalStyle.jsx
+++ b/components/GlobalStyle.jsx
@@ -19,7 +19,7 @@ const GlobalStyle = () => (
       line-height: 130%;
     }
 
-    .content{
+    .content {
       padding: 0 3em 1em 3em;
       margin: 0 auto;
     }

--- a/components/GlobalStyle.jsx
+++ b/components/GlobalStyle.jsx
@@ -115,7 +115,7 @@ const GlobalStyle = () => (
 				text-align: center;
 				white-space: nowrap;
         text-decoration: none;
-        margin: 0.75em 0.5em 0 0;
+        margin: 0em 1em 0 0;
 			}
 
       h1 {

--- a/components/GlobalStyle.jsx
+++ b/components/GlobalStyle.jsx
@@ -193,7 +193,6 @@ const GlobalStyle = () => (
         color: #424242;
         background-color:#ffffff;
         border: #ffffff 1px solid;
-        display: flex;
         padding: 0.5em;
         margin: 0.75em 0.5em 0 0;
       }

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -22,7 +22,7 @@ const Header = (props) => (
 
         <style jsx>{`
 			#logo-small {
-				max-width: 3em;
+				max-width: 4em;
 				margin: 1em;
 				cursor:pointer;
 			}
@@ -37,7 +37,6 @@ const Header = (props) => (
 
       		ul {
 				list-style-type: none;
-				margin:0em;
 				min-height: 3em;
 				display: flex;
 				align-items : first baseline;
@@ -50,7 +49,8 @@ const Header = (props) => (
 			}
 
 			li img {
-        		max-height: 1.5em;
+				max-height: 1.5em;
+				vertical-align: bottom;
 			}
 
 			@media (max-width: 720px) {
@@ -58,8 +58,10 @@ const Header = (props) => (
 					flex-direction: column;
 					justyfy-content: stretch;
 				}
+
 				ul {
-       				padding: 0;
+       				display: flex;
+          			padding: 0.2rem;
           			flex-direction: column;
           			align-items: center;
 				}

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -14,7 +14,7 @@ const Hero = () => (
       </ul>
     </nav>
 
-    <div className="content flex-baseline">
+    <div className="content">
       <img src="static/images/logo_main.svg" alt="OpenFisca"/>
       <p className="baseline" >La plateforme Open Source qui modélise <br /> le code législatif en code informatique.</p>
       <Link href="https://openfisca.org/doc/" passHref><a className="btn CTA">Commencer <img src={asset('/icons/Rocket.svg') } alt="" /></a></Link>
@@ -29,36 +29,26 @@ const Hero = () => (
         padding-bottom: 10%;
         }
 
-      .flex-baseline {
-        display: -webkit-box;
-        display: -moz-box;
-        display: -ms-flexbox;
-        display: -webkit-flex;
-        display: flex;
-        -webkit-flex-direction: column;
-        -ms-flex-direction: column;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        margin-top: 10%;
-      }
-
 			.logo {
 				max-width: 4em;
 				margin: 1em;
 				cursor:pointer;
       }
 
-      img {
-        max-width: 30em;
+      .content {
+        text-align: center;
       }
 
-      .baseline{
+      .baseline {
         color: #ffffff;
         font-size: 1.5em;
         line-height: 1.75em;
         font-family: "asapmedium";
         font-style: normal;
+      }
+
+      img {
+        max-width: 30em;
       }
 
       ul {

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -16,7 +16,7 @@ const Hero = () => (
 
     <div className="content">
       <img src="static/images/logo_main.svg" alt="OpenFisca"/>
-      <p className="baseline" >La plateforme Open Source qui modélise <br /> le code législatif en code informatique.</p>
+      <p className="baseline" >La plateforme Open Source qui modélise <br/> le code législatif en code informatique.</p>
       <Link href="https://openfisca.org/doc/" passHref><a className="btn CTA">Commencer <img src={asset('/icons/Rocket.svg')} alt="" /></a></Link>
     </div>
 
@@ -68,6 +68,7 @@ const Hero = () => (
 
 			li img {
         max-height: 1.5em;
+        vertical-align: bottom;
 			}
 
 			h3 {
@@ -80,7 +81,6 @@ const Hero = () => (
       }
 
       @media (max-width:880px) {
-
         .logo {
           display: flex;
           flex-direction: column;

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -50,6 +50,7 @@ const Hero = () => (
 
       img {
         max-width: 30em;
+        vertical-align: middle;
       }
 
       ul {

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -17,7 +17,7 @@ const Hero = () => (
     <div className="content">
       <img src="static/images/logo_main.svg" alt="OpenFisca"/>
       <p className="baseline" >La plateforme Open Source qui modélise <br /> le code législatif en code informatique.</p>
-      <Link href="https://openfisca.org/doc/" passHref><a className="btn CTA">Commencer <img src={asset('/icons/Rocket.svg') } alt="" /></a></Link>
+      <Link href="https://openfisca.org/doc/" passHref><a className="btn CTA">Commencer <img src={asset('/icons/Rocket.svg')} alt="" /></a></Link>
     </div>
 
     <style jsx>{`
@@ -27,7 +27,7 @@ const Hero = () => (
         background-size: cover;
         background-repeat: no-repeat;
         padding-bottom: 10%;
-        }
+      }
 
 			.logo {
 				max-width: 4em;
@@ -55,7 +55,6 @@ const Hero = () => (
 
       ul {
 				list-style-type: none;
-				margin:0em;
 				min-height: 3em;
 				display: flex;
 				align-items : first baseline;

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -37,6 +37,7 @@ const Hero = () => (
 
       .content {
         text-align: center;
+        margin-top: 10%;
       }
 
       .baseline {

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -50,7 +50,7 @@ const Hero = () => (
 
       img {
         max-width: 30em;
-        vertical-align: middle;
+        vertical-align: bottom;
       }
 
       ul {


### PR DESCRIPTION
Fixes #37 

Centre le logo de l'en-tête de la page d'accueil.
Centre le texte sous le logo.
Supprime le css sans effet identifié.