### PR TITLE
Corrige le dimensionnement du bouton de code source

### DIFF
--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -8,10 +8,10 @@ const Footer = () => (
                 <a href="https://openfisca.org/doc/" className="btn CTA">Commencer <img src="/static/icons/Rocket.svg"></img></a>
             </div>
             <ul>
-                <li><Link href="/status" passHref>Etat des services</Link></li>
-                <li><Link href="/cookies" passHref>Informatique & libertés</Link></li>
-                <li><Link href="/legal" passHref>Mentions légales</Link></li>
-                <li><Link href="/contribute" passHref>Contribuer</Link></li>
+                <li><Link href="/status" passHref><a>Etat des services</a></Link></li>
+                <li><Link href="/cookies" passHref><a>Informatique & libertés</a></Link></li>
+                <li><Link href="/legal" passHref><a>Mentions légales</a></Link></li>
+                <li><Link href="/contribute" passHref><a>Contribuer</a></Link></li>
             </ul>
             <ul className="social">
                 <li><a href="mailto:contact@openfisca.org?Subject=openfisca.org" passHref><img src="/static/icons/Email.svg" alt="Envoyer un email"></img></a></li>

--- a/components/GlobalStyle.jsx
+++ b/components/GlobalStyle.jsx
@@ -191,7 +191,6 @@ const GlobalStyle = () => (
       // buttons
       .CTA {
         color: #424242;
-        text-decoration:none;
         background-color:#ffffff;
         border: #ffffff 1px solid;
         display: flex;
@@ -199,7 +198,7 @@ const GlobalStyle = () => (
         margin: 0.75em 0.5em 0 0;
       }
 
-      .btn{
+      .btn {
         -moz-box-shadow: 0px 10px 10px 0px #42424226;
         -webkit-box-shadow: 0px 10px 10px 0px #42424226;
         box-shadow: 0px 10px 10px 0px #42424226;
@@ -223,8 +222,8 @@ const GlobalStyle = () => (
       }
 
       .outline {
-        border: #ffffff 1px solid;
         color: #ffffff;
+        border: #ffffff 1px solid;
         display: flex;
         padding: 0.5em;
         margin: 0.75em 0.5em 0 0;

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -12,7 +12,7 @@ const Header = (props) => (
                 <li><Link href="/showcase/" passHref><a className="menu">Projets</a></Link></li>
                 <li><Link href="/resources" passHref><a className="menu">Ressources</a></Link></li>
                 <li><Link href="/community" passHref><a className="menu">Communauté</a></Link></li>
-                <li><a className="btn outline" href="https://github.com/openfisca/openfisca-france">Code source <img src={asset('/icons/github.svg')} alt=""/></a></li>
+                <li><a className="btn outline" href="https://github.com/openfisca/openfisca-france">Code source <img src={asset('/icons/github.svg')} alt="github.com"/></a></li>
                 <li><Link href="https://openfisca.org/doc/" passHref><a className="btn CTA">Commencer <img src={asset('/icons/Rocket.svg')} /></a></Link></li>
             </ul>
             <h1>{props.title}</h1>
@@ -47,11 +47,6 @@ const Header = (props) => (
 			li {
 				display: inline;
 				list-style: none;
-			}
-
-			li img {
-				max-width: 1.5em;
-        		vertical-align: middle;
 			}
 
 			@media (max-width: 720px) {

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -49,6 +49,10 @@ const Header = (props) => (
 				list-style: none;
 			}
 
+			li img {
+        		max-height: 1.5em;
+			}
+
 			@media (max-width: 720px) {
 				header{
 					flex-direction: column;

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -76,8 +76,7 @@ const Hero = () => (
 			}
 
 			li img {
-				max-width: 1.5em;
-        vertical-align: middle;
+        max-height: 1.5em;
 			}
 
 			h3 {


### PR DESCRIPTION
Sur toutes les pages du site, corrige la dimension de l'icône du bouton de "Code source". Et par là, corrige l'écart de dimension entre ce bouton et le bouton "Commencer"

Avant :

![Screen Shot 2019-05-09 at 19 43 31](https://user-images.githubusercontent.com/6567910/57474645-df615380-7292-11e9-9d79-fee5dffbe7ce.png)


Après : 

![Screen Shot 2019-05-09 at 19 43 46](https://user-images.githubusercontent.com/6567910/57474659-e8522500-7292-11e9-8e87-63cec9c676f9.png)
