### PR TITLE
Ajoute StrikeBanner pour soutenir la grève du 5/12

### DIFF
--- a/components/StrikeBanner.jsx
+++ b/components/StrikeBanner.jsx
@@ -1,0 +1,50 @@
+const StrikeBanner = () => (
+    <div className="banner">
+        <div className="banner_container">
+            <div className="banner_icon">⚠️</div>
+            <div className="banner_label">
+                <p className="banner_title">En raison d’un appel interprofessionnel à la grève contre la réforme des retraites, une partie de l’équipe ne travaille pas.</p>
+                <p className="banner_subtitle">Les délais de réponse aux questions techniques pourront être perturbés pendant les prochains jours.</p>
+            </div>
+        </div>
+
+        <style jsx>
+            {`
+                .banner {
+                  width: 100%;
+                  margin: 0;
+                  padding: 16px;
+                  color: #333;
+                  background-color: #FEF3B8;
+                  font-family: Helvetica, sans-serif;
+                }
+
+                .banner_container {
+                  display: flex;
+                  align-items: center;
+                  max-width: 1024px;
+                  margin: auto;
+                }
+
+                .banner_icon {
+                  margin-right: 16px;
+                  font-size: 30px;
+                  opacity: 0.7;
+                }
+
+                .banner_title,
+                .banner_subtitle {
+                  margin: 0;
+                  padding: 0;
+                  line-height: 22px;
+                }
+
+                .banner_title {
+                  font-weight: bold;
+                }
+            `}
+        </style>
+    </div>
+)
+
+export default StrikeBanner

--- a/layouts/Home.jsx
+++ b/layouts/Home.jsx
@@ -1,4 +1,5 @@
 import Head from "next/head"
+import StrikeBanner from "components/StrikeBanner"
 import Footer from "components/Footer"
 import Piwik from "components/Piwik"
 import "styles/theme.scss"
@@ -12,6 +13,7 @@ OpenFisca:
             </title>
             <meta name="viewport" key="viewport" content="initial-scale=1.0, width=device-width" />
         </Head>
+        <StrikeBanner />
         {children}
         <Footer />
         <Piwik page={page} />


### PR DESCRIPTION
En raison d’un appel interprofessionnel à la grève contre la réforme des retraites, une partie de l’équipe ne travaille pas.

<img width="1431" alt="Capture d’écran 2019-12-04 à 08 14 19" src="https://user-images.githubusercontent.com/329236/70121261-8615a300-166e-11ea-918c-249af349ebe0.png">
