### PR TITLE
Add reference to "rules as code" in landing

### DIFF
--- a/public/locales/en/index.json
+++ b/public/locales/en/index.json
@@ -7,7 +7,7 @@
     "start": "Getting started",
 
     "pitch1": "The open source platform",
-    "pitch2": "that turns rules into code.",
+    "pitch2": "to write rules as code.",
 
     "everything": "Everything you can do with OpenFisca",
     "title-economists":"For economists",

--- a/public/locales/en/index.json
+++ b/public/locales/en/index.json
@@ -7,7 +7,7 @@
     "start": "Getting started",
 
     "pitch1": "The open source platform",
-    "pitch2": "that turns law into software.",
+    "pitch2": "that turns rules into code.",
 
     "everything": "Everything you can do with OpenFisca",
     "title-economists":"For economists",
@@ -20,7 +20,7 @@
 
     "title-how":"How does it work?",
     "content-how":"OpenFisca is a free, reusable, modular open source project. Il permet de modéliser le code législatif en code informatique, pour améliorer la transparence et l’accès à la loi.",
-    
+
     "feature1-list-a":"Use an existing tax & benefit system existant",
     "feature1-list-b": "Build your own system",
     "feature1-list-c": "Improve an existing system",


### PR DESCRIPTION
As "rules as code" becomes the standard theoretical framework within whom OpenFisca is referenced, I think it will help less microsimulation-savvy people to find themselves in the website.

Part of https://trello.com/c/M0VU1GTy/18-cross-reference-doc-with-rac