### PR TITLE
Redirect API and reverse-proxy Legislation Explorer

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,2 @@
 /api/* https://api.fr.openfisca.org/:splat 302
-/legislation/* https://legislation.fr.openfisca.org/legislation/:splat 200
+/legislation/* https://legislation.fr.openfisca.org/:splat 302


### PR DESCRIPTION
Related to https://github.com/openfisca/openfisca-ops/pull/95 and https://github.com/openfisca/legislation-explorer/pull/231

The API and the Legislation Explorer for OpenFisca-France have been migrated to a new server.

This PR updates the Netlify settings to:

- redirect (permanently) `/api` to the new domain `api.fr.openfisca.org` (to ensure backward compatibility with the legacy URL `https://fr.openfisca.org/api`
- reverse-proxy `/legislation` to `legislation.fr.openfisca.org`

A proof of concept has been made with a [test project](https://github.com/cbenz/test-netlify-proxy) which is deployed to `optimistic-turing-350a61.netlify.app`:

- https://optimistic-turing-350a61.netlify.app/api/latest redirects permanently to https://api.fr.openfisca.org/api/latest
- https://optimistic-turing-350a61.netlify.app/legislation reverse-proxies https://fr.openfisca.org/legislation/ (as `legislation.fr.openfisca.org` is not yet ready)

Along with this PR, the DNS zone has to be updated to make the domain `fr.openfisca.org` point to Netlify, and actually use the `_redirects` config file.

More context: the `_redirects` file was present in the source code repository but wasn't actually used, because the DNS zone configured the domain `fr.openfisca.org` to point to the server, which reverse-proxies the Netlify website on `site.fr.openfisca.org`, and reverse-proxies also `/legislation` on `localhost:2030`. So Netlify did not actually received the `https://fr.openfisca.org/legislation` requests.